### PR TITLE
Ensure value() is an object before calling method_exists

### DIFF
--- a/src/ArrayCriteriaVisitor.php
+++ b/src/ArrayCriteriaVisitor.php
@@ -47,7 +47,7 @@ class ArrayCriteriaVisitor implements FilterVisitorInterface
             static function ($item) use ($filter) {
                 if (\method_exists($item, $filter->field()->value())) {
                     $field = $filter->field()->value();
-                    $itemValue = \method_exists($item->$field(), 'value')
+                    $itemValue = true === \is_object($item->$field()) && \method_exists($item->$field(), 'value')
                         ? $item->$field()->value()
                         : $item->$field();
 


### PR DESCRIPTION
In some cases, value can be an integer, so we are having `TypeException` errors, like:

```
method_exists(): Argument #1 ($object_or_class) must be of type object|string, int given
```